### PR TITLE
Support compact format file configuration

### DIFF
--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -29,8 +29,9 @@ module.exports = function(grunt) {
       if (min.length < 1) {
         grunt.log.warn('Destination not written because minified CSS was empty.');
       } else {
-        grunt.file.write(f.dest, min);
-        grunt.log.writeln('File ' + f.dest + ' created.');
+        var dest = f.dest || f.src[0];
+        grunt.file.write(dest, min);
+        grunt.log.writeln('File ' + dest + ' created.');
         helper.minMaxInfo(min, max);
       }
     });


### PR DESCRIPTION
Allows the following configuration to in-place compress a single file:

``` json
{"cssmin": {
    "compress": {
        "src": ["styles/app.css"]
    }
}}
```

Note: This does not support in-place minification of multiple files. More refactoring would be needed for that. IMHO this task should not do concatenation at all, as there is grunt-contrib-concat to do that. (Or at least make it optional?)
