### PR TITLE
Speed up minification by making gzip reporting configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ Type: `String` `Number`
 Default: `'*'`
 
 To keep or remove special comments, exposing the underlying option from [clean-css](https://github.com/GoalSmashers/clean-css).. `'*'` for keeping all (default), `1` for keeping first one, `0` for removing all.
+
+#### report
+Choices: `false`, `'min'`, `'gzip'`
+Default: `false`
+
+Either do not report anything, report only minification result, or report minification and gzip results.
+This is useful to see exactly how well clean-css is performing but using `'gzip'` will make the task take 5-10x longer to complete.
+
+Example ouput using `'gzip'`:
+
+```
+Original: 198444 bytes.
+Minified: 101615 bytes.
+Gzipped:  20084 bytes.
+```
 ### Usage Examples
 
 ```js
@@ -81,4 +96,4 @@ cssmin: {
 
 Task submitted by [Tim Branyen](http://goingslowly.com/)
 
-*This file was generated on Sun Mar 10 2013 19:09:35.*
+*This file was generated on Thu Mar 14 2013 18:09:22.*

--- a/docs/cssmin-options.md
+++ b/docs/cssmin-options.md
@@ -13,3 +13,18 @@ Type: `String` `Number`
 Default: `'*'`
 
 To keep or remove special comments, exposing the underlying option from [clean-css](https://github.com/GoalSmashers/clean-css).. `'*'` for keeping all (default), `1` for keeping first one, `0` for removing all.
+
+## report
+Choices: `false`, `'min'`, `'gzip'`
+Default: `false`
+
+Either do not report anything, report only minification result, or report minification and gzip results.
+This is useful to see exactly how well clean-css is performing but using `'gzip'` will make the task take 5-10x longer to complete.
+
+Example ouput using `'gzip'`:
+
+```
+Original: 198444 bytes.
+Minified: 101615 bytes.
+Gzipped:  20084 bytes.
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-cssmin",
   "description": "Compress CSS files.",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "homepage": "https://github.com/gruntjs/grunt-contrib-cssmin",
   "author": {
     "name": "Grunt Team",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "clean-css": "~0.10.0",
-    "grunt-lib-contrib": "~0.5.1"
+    "grunt-lib-contrib": "~0.6.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.2.0",

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -12,7 +12,9 @@ module.exports = function(grunt) {
   var helper = require('grunt-lib-contrib').init(grunt);
 
   grunt.registerMultiTask('cssmin', 'Minify CSS files', function() {
-    var options = this.options();
+    var options = this.options({
+      report: false
+    });
     this.files.forEach(function(f) {
       var max = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
@@ -35,7 +37,9 @@ module.exports = function(grunt) {
         }
         grunt.file.write(f.dest, min);
         grunt.log.writeln('File ' + f.dest + ' created.');
-        helper.minMaxInfo(min, max);
+        if(options.report) {
+          helper.minMaxInfo(min, max, options.report);
+        }
       }
     });
   });


### PR DESCRIPTION
This is an analogous change to https://github.com/gruntjs/grunt-contrib-uglify/pull/35. Calculating gzipped size massively slows down this task. I added the `report` option (recently supported in 0.6.0 of grunt-lib-contrib), and defaulted it to false.
