### PR TITLE
skipMinify option to speed dev workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,19 @@ Task targets, files and options may be specified according to the grunt [Configu
 Files are compressed with [clean-css](https://github.com/GoalSmashers/clean-css).
 ### Options
 
+#### skipMinify
+
+Type: `Boolean`
+Default: `false`
+
+If set to true, minification is skipped. This is useful if you'd like a concat file in your dev environment but don't want to slow the build with minification.
+
 #### banner
 
 Type: `String`
 Default: `null`
 
-Prefix the compressed source with the given banner, with a linebreak inbetween.
+Prefix the compressed source with the given banner, with a linebreak in between.
 
 #### keepSpecialComments
 

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -28,7 +28,15 @@ module.exports = function(grunt) {
       .map(grunt.file.read)
       .join(grunt.util.normalizelf(grunt.util.linefeed));
 
-      var min = minifyCSS(max, options);
+			// Option to skip minification.
+			// Allows for option of faster builds in development while still using a concat file
+      var min
+			if (options.skipMinify) {
+				min = max
+			} else {
+				min = minifyCSS(max, options);
+			}
+
       if (min.length < 1) {
         grunt.log.warn('Destination not written because minified CSS was empty.');
       } else {


### PR DESCRIPTION
I added an option to skip minification. This is useful if you'd like a concat file in your dev environment but don't want to slow the build with minification.

The change is small. I updated the task file and the readme but did not write a test :)
