### PR TITLE
Max file only calculated if report option is true

### DIFF
--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -27,9 +27,12 @@ module.exports = function(grunt) {
           return true;
         }
       });
-      var max = valid
-      .map(grunt.file.read)
-      .join(grunt.util.normalizelf(grunt.util.linefeed));
+      var max;
+      if(options.report) {
+        max = valid
+        .map(grunt.file.read)
+        .join(grunt.util.normalizelf(grunt.util.linefeed));
+      }
       var min = valid.map(function(f) {
         options.relativeTo = path.dirname(f);
         return minifyCSS(grunt.file.read(f), options);


### PR DESCRIPTION
It seems unnecessary to double the file reads on the source files for the purpose of calculating the original max filesize if the `report` option isn't `true`. In this PR, the max file is only combined if reporting is desired.
