### PR TITLE
Bumps chalk to 0.5.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "chalk": "~0.4.0",
+    "chalk": "~0.5.0",
     "clean-css": "~2.2.0",
     "maxmin": "~0.2.0"
   },


### PR DESCRIPTION
This version contains, amongst other things, a speed improvement larger than a factor fifty. Using this version may increase logging throughput.
