### PR TITLE
Updating Minify all contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,15 @@ cssmin: {
 #### Minify all contents of a release directory and add a `.min.css` extension
 ```js
 cssmin: {
-  files: [{
-    expand: true,
-    cwd: 'release/css/',
-    src: ['*.css', '!*.min.css'],
-    dest: 'release/css/',
-    ext: '.min.css'
-  }]
+  my_target: {
+    files: [{
+      expand: true,
+      cwd: 'release/css/',
+      src: ['*.css', '!*.min.css'],
+      dest: 'release/css/',
+      ext: '.min.css'
+    }]
+  }
 }
 ```
 


### PR DESCRIPTION
In all the grunt-contrib-\* the all contents needed to be with a target. When the target was missing you'd get an error 

```
Warning: Object #<Object> has no method 'indexOf'
```
