### PR TITLE
Upgrade to clean css 2.2.18. Fixes 143

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "chalk": "~0.5.0",
-    "clean-css": "~2.2.0",
+    "clean-css": "~2.2.18",
     "maxmin": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The change sets the minimum version of cleancss to 2.2.18. It fixes issue #143.
