### PR TITLE
Turn off rebase by default.

### DIFF
--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -19,6 +19,7 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('cssmin', 'Minify CSS', function () {
     this.files.forEach(function (file) {
       var options = this.options({
+        rebase: false,
         report: 'min',
         sourceMap: false
       });


### PR DESCRIPTION
This behavior is consistent with pre 0.12.x versions.

Refs #173.

/CC @sindresorhus: this fixes the issue for me. But I wonder if [this line](https://github.com/gruntjs/grunt-contrib-cssmin/commit/f825eab5c82ae5453059b9532d87f8ef2fa86470#diff-f0ee9eb300066e1e51fcfbad9d7a78e1R30) is really needed?