### PR TITLE
properly have a heartattack when CleanCSS fails fixes #194

### DIFF
--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -39,7 +39,7 @@ module.exports = function (grunt) {
 
         // something went mildly wrong
         if (compiled.warnings.length) {
-          grunt.warn(compiled.warnings.toString());
+          grunt.log.error(compiled.warnings.toString());
         }
 
         if (options.debug) {

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
         }
 
         if (options.debug) {
-          console.log(compiled.stats);
+          console.log.writeln(compiled.stats);
         }
       } catch (err) {
         grunt.log.error(err);

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -34,12 +34,12 @@ module.exports = function (grunt) {
 
         // something went horribly wrong
         if (compiled.errors.length) {
-          throw new Error(compiled.errors);
+          grunt.warn(compiled.errors);
         }
 
         // something went mildly wrong
         if (compiled.warnings.length) {
-          throw new Error(compiled.warnings);
+          grunt.warn(compiled.warnings);
         }
 
         if (options.debug) {

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -31,6 +31,20 @@ module.exports = function (grunt) {
 
       try {
         compiled = new CleanCSS(options).minify(availableFiles);
+
+        // something went horribly wrong
+        if (compiled.errors.length) {
+          throw new Error(compiled.errors);
+        }
+
+        // something went mildly wrong
+        if (compiled.warnings.length) {
+          throw new Error(compiled.warnings);
+        }
+
+        if (options.debug) {
+          console.log(compiled.stats);
+        }
       } catch (err) {
         grunt.log.error(err);
         grunt.warn('CSS minification failed');

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -34,12 +34,12 @@ module.exports = function (grunt) {
 
         // something went horribly wrong
         if (compiled.errors.length) {
-          grunt.warn(compiled.errors);
+          grunt.warn(compiled.errors.toString());
         }
 
         // something went mildly wrong
         if (compiled.warnings.length) {
-          grunt.warn(compiled.warnings);
+          grunt.warn(compiled.warnings.toString());
         }
 
         if (options.debug) {


### PR DESCRIPTION
as of 0.12.2 there is a stray `console.log` that appears on every run. it has subsequently been removed, but that also removes any information given by CleanCSS. This brings that information back and reacts appropriately when CleanCSS errors or warns, or when `debug` is turned on.