### PR TITLE
Fix absolute paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,8 @@
 'use strict';
+var path = require('path');
+function absolutePath(file) {
+  return path.join(__dirname, file);
+}
 module.exports = function (grunt) {
   grunt.initConfig({
     jshint: {
@@ -17,6 +21,15 @@ module.exports = function (grunt) {
     cssmin: {
       options: {
         sourceMap: true
+      },
+      absolute: {
+        files: [{
+          src: [
+            'test/fixtures/input_one.css',
+            'test/fixtures/input_two.css'
+          ].map(absolutePath),
+          dest: absolutePath('tmp/absolute.css')
+        }]
       },
       compress: {
         files: {

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -33,6 +33,7 @@ module.exports = function (grunt) {
       var compiled = '';
 
       options.target = file.dest;
+      options.relativeTo = path.dirname(availableFiles[0]);
 
       try {
         compiled = new CleanCSS(options).minify(availableFiles);

--- a/test/expected/absolute.css
+++ b/test/expected/absolute.css
@@ -1,0 +1,2 @@
+body{margin:0;font-size:18px}a{color:#00f}h1{font-size:48px;font-weight:700}
+/*# sourceMappingURL=absolute.css.map */

--- a/test/test.js
+++ b/test/test.js
@@ -19,5 +19,14 @@ exports.cssmin = {
     test.equal(expect, result, 'should inline @import');
 
     test.done();
+  },
+  absolute: function(test) {
+    test.expect(1);
+
+    var expect = grunt.file.read('test/expected/absolute.css').replace(/\r\n/g,'').replace(/\n/g,'');
+    var result = grunt.file.read('tmp/absolute.css').replace(/\r\n/g,'').replace(/\n/g,'');
+    test.equal(expect, result, 'should perform the standard tasks when given absolute paths');
+
+    test.done();
   }
 };


### PR DESCRIPTION
This should fix #191 and maybe #196 too.

The `relativeTo` option was removed at https://github.com/gruntjs/grunt-contrib-cssmin/pull/170/files#diff-f0ee9eb300066e1e51fcfbad9d7a78e1L45 and seemingly never added back.