### PR TITLE
Do not swallow Clean CSS errors.

### DIFF
--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -41,6 +41,9 @@ module.exports = function (grunt) {
 
       try {
         compiled = new CleanCSS(options).minify(availableFiles);
+        if (compiled.errors && compiled.errors.length) {
+            throw compiled.errors.join('\n');
+        }
       } catch (err) {
         grunt.log.error(err);
         grunt.warn('CSS minification failed at ' + availableFiles + '.');


### PR DESCRIPTION
The errors produced by Clean CSS were slightly swallowed, so throw them when they appear.
