### PR TITLE
Adds support for asynchronous processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "async": "^1.1.0",
     "chalk": "^1.0.0",
     "clean-css": "^3.1.0",
     "maxmin": "^1.1.0"

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -5,8 +5,10 @@ var util = require('util');
 var CleanCSS = require('clean-css');
 var chalk = require('chalk');
 var maxmin = require('maxmin');
+var async = require('async');
 
 module.exports = function (grunt) {
+  
   var getAvailableFiles = function (filesArray) {
     return filesArray.filter(function (filepath) {
       if (!grunt.file.exists(filepath)) {
@@ -18,6 +20,10 @@ module.exports = function (grunt) {
   };
 
   grunt.registerMultiTask('cssmin', 'Minify CSS', function () {
+    
+    var done = this.async();
+    var compileTasks = [];
+    var self = this;
     var created = {
       maps: 0,
       files: 0
@@ -28,6 +34,7 @@ module.exports = function (grunt) {
     };
 
     this.files.forEach(function (file) {
+      
       var options = this.options({
         rebase: false,
         report: 'min',
@@ -39,57 +46,70 @@ module.exports = function (grunt) {
 
       options.target = file.dest;
       options.relativeTo = path.dirname(availableFiles[0]);
-
-      try {
-        compiled = new CleanCSS(options).minify(availableFiles);
-
-        if (compiled.errors.length) {
-          grunt.warn(compiled.errors.toString());
-          return;
-        }
-
-        if (compiled.warnings.length) {
-          grunt.log.error(compiled.warnings.toString());
-        }
-
-        if (options.debug) {
-          grunt.log.writeln(util.format(compiled.stats));
-        }
-      } catch (err) {
-        grunt.log.error(err);
-        grunt.warn('CSS minification failed at ' + availableFiles + '.');
-      }
-
-      var compiledCssString = compiled.styles;
-
-      var unCompiledCssString = availableFiles.map(function (file) {
-        return grunt.file.read(file);
-      }).join('');
-
-      size.before += unCompiledCssString.length;
-
-      if (options.sourceMap) {
-        compiledCssString += '\n' + '/*# sourceMappingURL=' + path.basename(file.dest) + '.map */';
-        grunt.file.write(file.dest + '.map', compiled.sourceMap.toString());
-        created.maps++;
-        grunt.verbose.writeln('File ' + chalk.cyan(file.dest + '.map') + ' created');
-      }
-
-      grunt.file.write(file.dest, compiledCssString);
-      created.files++;
-      size.after += compiledCssString.length;
-      grunt.verbose.writeln('File ' + chalk.cyan(file.dest) + ' created ' + chalk.dim(maxmin(unCompiledCssString, compiledCssString, options.report === 'gzip')));
+      
+      compileTasks.push(function(cb) {
+        new CleanCSS(options).minify(availableFiles, function(errors, compiled) {
+          return cb(null, {
+            'file': file,
+            'availableFiles': availableFiles,
+            'options': options,
+            'errors': errors || [],
+            'compiled': compiled
+          });
+        });
+      });
 
     }, this);
-
-    if (created.maps > 0) {
-      grunt.log.ok(created.maps + ' source' + grunt.util.pluralize(this.files.length, 'map/maps') + ' created.');
-    }
-
-    if (created.files > 0) {
-      grunt.log.ok(created.files + ' ' + grunt.util.pluralize(this.files.length, 'file/files') + ' created. ' + chalk.dim(maxmin(size.before, size.after)));
-    } else {
-      grunt.log.warn('No files created.');
-    }
+    
+    // done looping through files
+    
+    async.series(compileTasks, function(err, compiled) {
+      
+      if (err) {
+        grunt.warn(err.toString());
+        return done(false);
+      }
+      
+      compiled.forEach(function(comp) {
+        if (comp.errors.length) {
+          grunt.warn('CSS minification failed at ' + comp.availableFiles + '.');
+          grunt.warn(comp.errors.toString());
+          return;
+        }
+        if (comp.compiled.warnings.length) {
+          grunt.log.error(comp.compiled.warnings.toString());
+        }
+        if (comp.options.debug) {
+          grunt.log.writeln(util.format(comp.compiled.stats));
+        }
+        var compiledCssString = comp.compiled.styles;
+        var unCompiledCssString = comp.availableFiles.map(function (file) {
+          return grunt.file.read(file);
+        }).join('');
+        size.before += unCompiledCssString.length;
+        if (comp.options.sourceMap) {
+          compiledCssString += '\n' + '/*# sourceMappingURL=' + path.basename(comp.file.dest) + '.map */';
+          grunt.file.write(comp.file.dest + '.map', compiled.sourceMap.toString());
+          created.maps++;
+          grunt.verbose.writeln('File ' + chalk.cyan(comp.file.dest + '.map') + ' created');
+        }
+        grunt.file.write(comp.file.dest, compiledCssString);
+        created.files++;
+        size.after += compiledCssString.length;
+        grunt.verbose.writeln('File ' + chalk.cyan(comp.file.dest) + ' created ' + chalk.dim(maxmin(unCompiledCssString, compiledCssString, comp.options.report === 'gzip')));
+      });
+      
+        if (created.maps > 0) {
+          grunt.log.ok(created.maps + ' source' + grunt.util.pluralize(self.files.length, 'map/maps') + ' created.');
+        }
+    
+        if (created.files > 0) {
+          grunt.log.ok(created.files + ' ' + grunt.util.pluralize(self.files.length, 'file/files') + ' created. ' + chalk.dim(maxmin(size.before, size.after)));
+        } else {
+          grunt.log.warn('No files created.');
+        }
+      
+    });
+    
   });
 };

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -108,6 +108,8 @@ module.exports = function (grunt) {
         } else {
           grunt.log.warn('No files created.');
         }
+        
+        done();
       
     });
     


### PR DESCRIPTION
In order for `clean-css` to process `@import` calls that reference remote resources, the library *must* be called asynchronously, as [documented here](https://github.com/jakubpawlowicz/clean-css#how-to-make-sure-remote-imports-are-processed-correctly).

Grunt-contrib-cssmin does not currently do this. As a result, any attempts to compile css files that reference remote resources fail. This PR fixes this issue.
