### PR TITLE
Fix clean-css version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "clean-css": "^3.1.0",
+    "clean-css": "~3.1.0",
     "maxmin": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix `clean-css` version to match the most recent minor version only.
I got bugs with lastest versions.