### PR TITLE
Allow the relativeTo option to be overridden

### DIFF
--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -28,17 +28,17 @@ module.exports = function (grunt) {
     };
 
     this.files.forEach(function (file) {
+      var availableFiles = getAvailableFiles(file.src);
       var options = this.options({
         rebase: false,
         report: 'min',
+        relativeTo: path.dirname(availableFiles[0]),
         sourceMap: false
       });
 
-      var availableFiles = getAvailableFiles(file.src);
       var compiled = '';
 
       options.target = file.dest;
-      options.relativeTo = path.dirname(availableFiles[0]);
 
       try {
         compiled = new CleanCSS(options).minify(availableFiles);


### PR DESCRIPTION
#203 blocked me from passing in my own relativeTo which I had been doing prior to cssmin 0.12.3. This keeps the existing functionality but allows users to pass in their own relativeTo url in if they so desire.