### PR TITLE
We need to manually add gzip-size since maxmin uses 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "clean-css": "~3.4.2",
-    "maxmin": "^2.1.0"
+    "maxmin": "^2.1.0",
+    "gzip-size": "2.1.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "clean-css": "~3.4.2",
-    "maxmin": "^2.1.0",
-    "gzip-size": "2.1.0"
+    "gzip-size": "2.1.0",
+    "maxmin": "^2.1.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
This fixes an issue where by it fails on nodejs 0.10 because maxmin uses version 3 of gzip-size which droped support for nodejs 0.10 so to work around this we include it manually.