### PR TITLE
Path implementation changed in node v6 to assert inputs as strings

### DIFF
--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
       var compiled = '';
 
       options.target = file.dest;
-      options.relativeTo = path.dirname(availableFiles[0]);
+      options.relativeTo = path.dirname(availableFiles[0] || '');
 
       try {
         compiled = new CleanCSS(options).minify(availableFiles);


### PR DESCRIPTION
Seems to keep the task running the same as before, in the issue I was having, when an input was a non-existent file and instead of creating an empty .css it broke the execution.

Fixes #270.