### PR TITLE
Update cssmin.js

### DIFF
--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -18,6 +18,8 @@ module.exports = function (grunt) {
   };
 
   grunt.registerMultiTask('cssmin', 'Minify CSS', function () {
+    var done = this.async();
+
     var created = {
       maps: 0,
       files: 0
@@ -27,7 +29,9 @@ module.exports = function (grunt) {
       after: 0
     };
 
-    this.files.forEach(function (file) {
+    var files = this.files;
+
+    files.forEach(function (file) {
       var options = this.options({
         rebase: false,
         report: 'min',
@@ -41,55 +45,60 @@ module.exports = function (grunt) {
       options.relativeTo = path.dirname(availableFiles[0]);
 
       try {
-        compiled = new CleanCSS(options).minify(availableFiles);
+        new CleanCSS(options).minify(availableFiles, function (error, minified) {
+          compiled = minified;
+          if (compiled.errors.length) {
+            grunt.warn(compiled.errors.toString());
+            return;
+          }
 
-        if (compiled.errors.length) {
-          grunt.warn(compiled.errors.toString());
-          return;
-        }
+          if (compiled.warnings.length) {
+            grunt.log.error(compiled.warnings.toString());
+          }
 
-        if (compiled.warnings.length) {
-          grunt.log.error(compiled.warnings.toString());
-        }
+          if (options.debug) {
+            grunt.log.writeln(util.format(compiled.stats));
+          }
 
-        if (options.debug) {
-          grunt.log.writeln(util.format(compiled.stats));
-        }
+          var compiledCssString = compiled.styles;
+
+          var unCompiledCssString = availableFiles.map(function (file) {
+            return grunt.file.read(file);
+          }).join('');
+
+          size.before += unCompiledCssString.length;
+
+          if (options.sourceMap) {
+            compiledCssString += '\n' + '/*# sourceMappingURL=' + path.basename(file.dest) + '.map */';
+            grunt.file.write(file.dest + '.map', compiled.sourceMap.toString());
+            created.maps++;
+            grunt.verbose.writeln('File ' + chalk.cyan(file.dest + '.map') + ' created');
+          }
+
+          grunt.file.write(file.dest, compiledCssString);
+          created.files++;
+          size.after += compiledCssString.length;
+          grunt.verbose.writeln('File ' + chalk.cyan(file.dest) + ' created ' + chalk.dim(maxmin(
+            unCompiledCssString, compiledCssString, options.report === 'gzip')));
+
+          if (created.maps > 0) {
+            grunt.log.ok(created.maps + ' source' + grunt.util.pluralize(files.length, 'map/maps') +
+              ' created.');
+          }
+
+          if (created.files > 0) {
+            grunt.log.ok(created.files + ' ' + grunt.util.pluralize(files.length, 'file/files') +
+              ' created. ' + chalk.dim(maxmin(size.before, size.after)));
+          } else {
+            grunt.log.warn('No files created.');
+          }
+
+          done();
+        });
       } catch (err) {
         grunt.log.error(err);
         grunt.warn('CSS minification failed at ' + availableFiles + '.');
       }
-
-      var compiledCssString = compiled.styles;
-
-      var unCompiledCssString = availableFiles.map(function (file) {
-        return grunt.file.read(file);
-      }).join('');
-
-      size.before += unCompiledCssString.length;
-
-      if (options.sourceMap) {
-        compiledCssString += '\n' + '/*# sourceMappingURL=' + path.basename(file.dest) + '.map */';
-        grunt.file.write(file.dest + '.map', compiled.sourceMap.toString());
-        created.maps++;
-        grunt.verbose.writeln('File ' + chalk.cyan(file.dest + '.map') + ' created');
-      }
-
-      grunt.file.write(file.dest, compiledCssString);
-      created.files++;
-      size.after += compiledCssString.length;
-      grunt.verbose.writeln('File ' + chalk.cyan(file.dest) + ' created ' + chalk.dim(maxmin(unCompiledCssString, compiledCssString, options.report === 'gzip')));
-
     }, this);
-
-    if (created.maps > 0) {
-      grunt.log.ok(created.maps + ' source' + grunt.util.pluralize(this.files.length, 'map/maps') + ' created.');
-    }
-
-    if (created.files > 0) {
-      grunt.log.ok(created.files + ' ' + grunt.util.pluralize(this.files.length, 'file/files') + ' created. ' + chalk.dim(maxmin(size.before, size.after)));
-    } else {
-      grunt.log.warn('No files created.');
-    }
   });
 };


### PR DESCRIPTION
Added callback to CleanCSS.minify function

I got this warning every time I used `grunt-contrib-cssmin` to combine multiple css files:

``` terminal
>> Ignoring remote @import of "https://fonts.googleapis.com/css?family=Roboto:300,400,400i,500,700,700i|Montserrat:400,700" as no callback given.
```

So I added the callback, and it works!! :+1:
