### PR TITLE
Use new rebase configuration for clean-css@4

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,6 +53,16 @@ module.exports = function (grunt) {
             'test/fixtures/inner/input_inline_import.css'
           ]
         }
+      },
+      rebase: {
+        options: {
+          rebase: true
+        },
+        files: {
+          'tmp/rebase.css': [
+            'test/fixtures/rebase.css'
+          ]
+        }
       }
     },
     nodeunit: {

--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -37,8 +37,7 @@ module.exports = function (grunt) {
       var availableFiles = getAvailableFiles(file.src);
       var compiled = '';
 
-      options.target = file.dest;
-      options.relativeTo = path.dirname(availableFiles[0] || '');
+      options.rebaseTo = path.dirname(file.dest);
 
       try {
         compiled = new CleanCSS(options).minify(availableFiles);

--- a/test/expected/rebase.css
+++ b/test/expected/rebase.css
@@ -1,0 +1,1 @@
+body{background:url(../test/fixtures/test.jpg)}/*# sourceMappingURL=rebase.css.map */

--- a/test/fixtures/rebase.css
+++ b/test/fixtures/rebase.css
@@ -1,0 +1,3 @@
+body {
+  background: url('test.jpg');
+}

--- a/test/test.js
+++ b/test/test.js
@@ -33,5 +33,14 @@ exports.cssmin = {
     test.equal(expect, result, 'should perform the standard tasks when given absolute paths');
 
     test.done();
+  },
+  rebase: function(test) {
+    test.expect(1);
+
+    var expect = readFileAndRemoveNewlines('test/expected/rebase.css');
+    var result = readFileAndRemoveNewlines('tmp/rebase.css');
+    test.equal(expect, result, 'should rebase url imports correctly');
+
+    test.done();
   }
 };


### PR DESCRIPTION
The options target and relativeTo have been replaced by rebaseTo.

This patch also adds a unit test. I tested this with grunt-contrib-cssmin@1 (with clean-css@3) and the results are the same. Without the change in tasks/cssmin.js the results are different.