### PR TITLE
Allowed rebasedTo to be changed again

### DIFF
--- a/tasks/cssmin.js
+++ b/tasks/cssmin.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
       var availableFiles = getAvailableFiles(file.src);
       var compiled = '';
 
-      options.rebaseTo = path.dirname(file.dest);
+      options.rebaseTo = !!options.rebaseTo ? options.rebaseTo : path.dirname(file.dest);
 
       try {
         compiled = new CleanCSS(options).minify(availableFiles);


### PR DESCRIPTION
rebasedTo was set to Build-Dir.
Now Build-Dir is only fallback and the variable can be changed like intended.